### PR TITLE
Removed app token

### DIFF
--- a/dist/enplug-player-sdk.bundle.js
+++ b/dist/enplug-player-sdk.bundle.js
@@ -110,6 +110,7 @@ var RESPONSE_TIMEOUT = 60 * 1000;
 
 var epBridge = null;
 var responseMap = new Map();
+var appToken = null;
 
 /**
  * Creates a unique token used to identify apprpriate message response function.
@@ -190,6 +191,13 @@ epBridge.receive = function (json) {
 
     console.log('[Player SDK] Received message with action ' + action, data);
 
+    if (data && data.action === 'set-app-token') {
+      console.log('[Player SDK] Storing appToken ' + data.appToken);
+      appToken = data.appToken;
+      sessionStorage.setItem('appToken', data.appToken);
+      localStorage.setItem('appToken', data.appToken);
+    }
+
     // if there is a token we can just resolve the promise and be done
     // if it was an error the payload has been transformed to an error
     //    so we can just reject the promise with that error
@@ -204,7 +212,7 @@ epBridge.receive = function (json) {
     // if we pass more info in the payload this will
     // need to be changed to not throw that data away
     if (isError) {
-      console.error('[Player SDK] Error received: ' + payload.message, payload);
+      console.log('[Player SDK] Error received: ' + payload.message, payload);
       // tweak payload to be the error object
       payload = new _EnplugError2.default(payload.message || '');
     }
@@ -251,11 +259,11 @@ exports.default = {
     }, message);
     var url = window.location.href;
 
-    console.log('[Player SDK] Sending message to URL ' + url);
+    console.debug('[Player SDK] Sending message to URL ' + url + ' with appToken ' + appToken);
+    console.debug('[Player SDK] Session storage', sessionStorage);
 
     // appToken identifies specific instance of the App.
-    var match = url.match(/apptoken=([^&]*[a-z|0-9])/);
-    msg.appToken = match && match[1] || '';
+    msg.appToken = sessionStorage.getItem('appToken');
 
     // We need to send app url with the message so that Web Player knows which application sent
     // a message.
@@ -768,6 +776,24 @@ exports.default = {
     }).then(function (payload) {
       console.log('[Player SDK] Settings: Returning setting get-locale: ' + (payload && payload.value));
       return payload && payload.value ? payload.value : 'en';
+    });
+  },
+
+  get orientation() {
+    return settingsSender({
+      action: 'get-orientation'
+    }).then(function (payload) {
+      console.log('[Player SDK] Settings: Returning setting get-orientation: ' + (payload && payload.value));
+      return payload && payload.value;
+    });
+  },
+
+  get zoning() {
+    return settingsSender({
+      action: 'get-zoning-info'
+    }).then(function (payload) {
+      console.log('[Player SDK] Settings: Returning setting get-zoning-info: ' + (payload && payload.value));
+      return payload && payload.value;
     });
   }
 };

--- a/dist/enplug-player-sdk.bundle.js
+++ b/dist/enplug-player-sdk.bundle.js
@@ -111,6 +111,7 @@ var RESPONSE_TIMEOUT = 60 * 1000;
 var epBridge = null;
 var responseMap = new Map();
 var appToken = null;
+var isZoningApp = false;
 var delayedMessages = [];
 
 /**
@@ -130,6 +131,7 @@ function createToken() {
 // send and receive messages from the Web Player.
 try {
   (function () {
+    isZoningApp = !!window.location.href && !!window.location.href.indexOf('zoning=true');
     var $global = Function('return this')(); // eslint-disable-line
 
     // _epBridge exists: Java Player
@@ -270,6 +272,10 @@ exports.default = {
     console.log('[Player SDK] Sending message to URL ' + url + ' with appToken ' + appToken);
 
     // appToken identifies specific instance of the App.
+    if (!appToken) {
+      var match = url.match(/apptoken=([^&]*[a-z|0-9])/);
+      appToken = match && match[1] || '';
+    }
     msg.appToken = appToken;
 
     // We need to send app url with the message so that Web Player knows which application sent
@@ -301,7 +307,7 @@ exports.default = {
       responseMap.set(token, [resolve, reject]);
       msg.token = token;
 
-      if (!appToken) {
+      if (isZoningApp && !appToken) {
         delayedMessages.push(msg);
       } else {
         console.log('[Player SDK] Message to be sent: ' + JSON.stringify(msg));

--- a/dist/enplug-player-sdk.bundle.js
+++ b/dist/enplug-player-sdk.bundle.js
@@ -131,18 +131,18 @@ function createToken() {
 // send and receive messages from the Web Player.
 try {
   (function () {
-    isZoningApp = !!window.location.href && !!window.location.href.indexOf('zoning=true');
+    isZoningApp = !!window.location.href && window.location.href.indexOf('zoning=true') >= 0;
+    console.log('[Player SDK] Zoning App detected: ' + isZoningApp);
     var $global = Function('return this')(); // eslint-disable-line
 
     // _epBridge exists: Java Player
     if ($global.hasOwnProperty('_epBridge')) {
-      console.log('[Enplug SDK] Creating bridge from standard implementation.');
+      console.log('[Player SDK] Creating bridge from standard implementation.');
       epBridge = $global._epBridge;
     }
-
     // _epBridge doesn't exist but _epBridgeSend exists: Windows (CEF) Player
     else if ($global.hasOwnProperty('_epBridgeSend')) {
-        console.log('[Enplug SDK] Creating bridge from CEF implementation.');
+        console.log('[Player SDK] Creating bridge from CEF implementation.', $global._epBridge);
         epBridge = $global._epBridge = {
           send: function send(message) {
             $global._epBridgeSend({
@@ -238,7 +238,7 @@ epBridge.receive = function (json) {
       (0, _events.processEvent)(action, payload, meta);
     }
   } catch (err) {
-    console.error('[Enplug SDK] Error receiving and processing message in _epBridge.receive');
+    console.error('[Player SDK] Error receiving and processing message in _epBridge.receive');
     console.error(err.stack);
   }
 
@@ -285,11 +285,11 @@ exports.default = {
     msg.appUrl = appUrl;
 
     if (!msg.hasOwnProperty('service') || typeof msg.service !== 'string') {
-      return Promise.reject(new TypeError('[Enplug SDK] Bridge message requires a service property (string)'));
+      return Promise.reject(new TypeError('[Player SDK] Bridge message requires a service property (string)'));
     }
 
     if (!msg.hasOwnProperty('action') || typeof msg.action !== 'string') {
-      return Promise.reject(new TypeError('[Enplug SDK] Bridge message requires an action property (string)'));
+      return Promise.reject(new TypeError('[Player SDK] Bridge message requires an action property (string)'));
     }
 
     if (noReturn) {
@@ -308,9 +308,10 @@ exports.default = {
       msg.token = token;
 
       if (isZoningApp && !appToken) {
+        console.log('[Player SDK] Sending message from an App inside Zoning: ' + JSON.stringify(msg), msg);
         delayedMessages.push(msg);
       } else {
-        console.log('[Player SDK] Message to be sent: ' + JSON.stringify(msg));
+        console.log('[Player SDK] Sending message from an App outside of Zoning: ' + JSON.stringify(msg), msg);
         epBridge.send(JSON.stringify(msg));
       }
     });

--- a/dist/es5/bridge.js
+++ b/dist/es5/bridge.js
@@ -67,18 +67,18 @@ function createToken() {
 // send and receive messages from the Web Player.
 try {
   (function () {
-    isZoningApp = !!window.location.href && !!window.location.href.indexOf('zoning=true');
+    isZoningApp = !!window.location.href && window.location.href.indexOf('zoning=true') >= 0;
+    console.log('[Player SDK] Zoning App detected: ' + isZoningApp);
     var $global = Function('return this')(); // eslint-disable-line
 
     // _epBridge exists: Java Player
     if ($global.hasOwnProperty('_epBridge')) {
-      console.log('[Enplug SDK] Creating bridge from standard implementation.');
+      console.log('[Player SDK] Creating bridge from standard implementation.');
       epBridge = $global._epBridge;
     }
-
     // _epBridge doesn't exist but _epBridgeSend exists: Windows (CEF) Player
     else if ($global.hasOwnProperty('_epBridgeSend')) {
-        console.log('[Enplug SDK] Creating bridge from CEF implementation.');
+        console.log('[Player SDK] Creating bridge from CEF implementation.', $global._epBridge);
         epBridge = $global._epBridge = {
           send: function send(message) {
             $global._epBridgeSend({
@@ -174,7 +174,7 @@ epBridge.receive = function (json) {
       (0, _events.processEvent)(action, payload, meta);
     }
   } catch (err) {
-    console.error('[Enplug SDK] Error receiving and processing message in _epBridge.receive');
+    console.error('[Player SDK] Error receiving and processing message in _epBridge.receive');
     console.error(err.stack);
   }
 
@@ -221,11 +221,11 @@ exports.default = {
     msg.appUrl = appUrl;
 
     if (!msg.hasOwnProperty('service') || typeof msg.service !== 'string') {
-      return _promise2.default.reject(new TypeError('[Enplug SDK] Bridge message requires a service property (string)'));
+      return _promise2.default.reject(new TypeError('[Player SDK] Bridge message requires a service property (string)'));
     }
 
     if (!msg.hasOwnProperty('action') || typeof msg.action !== 'string') {
-      return _promise2.default.reject(new TypeError('[Enplug SDK] Bridge message requires an action property (string)'));
+      return _promise2.default.reject(new TypeError('[Player SDK] Bridge message requires an action property (string)'));
     }
 
     if (noReturn) {
@@ -244,9 +244,10 @@ exports.default = {
       msg.token = token;
 
       if (isZoningApp && !appToken) {
+        console.log('[Player SDK] Sending message from an App inside Zoning: ' + (0, _stringify2.default)(msg), msg);
         delayedMessages.push(msg);
       } else {
-        console.log('[Player SDK] Message to be sent: ' + (0, _stringify2.default)(msg));
+        console.log('[Player SDK] Sending message from an App outside of Zoning: ' + (0, _stringify2.default)(msg), msg);
         epBridge.send((0, _stringify2.default)(msg));
       }
     });

--- a/dist/es5/bridge.js
+++ b/dist/es5/bridge.js
@@ -46,6 +46,7 @@ var RESPONSE_TIMEOUT = 60 * 1000;
 
 var epBridge = null;
 var responseMap = new _map2.default();
+var appToken = null;
 
 /**
  * Creates a unique token used to identify apprpriate message response function.
@@ -126,6 +127,13 @@ epBridge.receive = function (json) {
 
     console.log('[Player SDK] Received message with action ' + action, data);
 
+    if (data && data.action === 'set-app-token') {
+      console.log('[Player SDK] Storing appToken ' + data.appToken);
+      appToken = data.appToken;
+      sessionStorage.setItem('appToken', data.appToken);
+      localStorage.setItem('appToken', data.appToken);
+    }
+
     // if there is a token we can just resolve the promise and be done
     // if it was an error the payload has been transformed to an error
     //    so we can just reject the promise with that error
@@ -140,7 +148,7 @@ epBridge.receive = function (json) {
     // if we pass more info in the payload this will
     // need to be changed to not throw that data away
     if (isError) {
-      console.error('[Player SDK] Error received: ' + payload.message, payload);
+      console.log('[Player SDK] Error received: ' + payload.message, payload);
       // tweak payload to be the error object
       payload = new _EnplugError2.default(payload.message || '');
     }
@@ -187,11 +195,11 @@ exports.default = {
     }, message);
     var url = window.location.href;
 
-    console.log('[Player SDK] Sending message to URL ' + url);
+    console.debug('[Player SDK] Sending message to URL ' + url + ' with appToken ' + appToken);
+    console.debug('[Player SDK] Session storage', sessionStorage);
 
     // appToken identifies specific instance of the App.
-    var match = url.match(/apptoken=([^&]*[a-z|0-9])/);
-    msg.appToken = match && match[1] || '';
+    msg.appToken = sessionStorage.getItem('appToken');
 
     // We need to send app url with the message so that Web Player knows which application sent
     // a message.

--- a/dist/es5/bridge.js
+++ b/dist/es5/bridge.js
@@ -47,6 +47,7 @@ var RESPONSE_TIMEOUT = 60 * 1000;
 var epBridge = null;
 var responseMap = new _map2.default();
 var appToken = null;
+var isZoningApp = false;
 var delayedMessages = [];
 
 /**
@@ -66,6 +67,7 @@ function createToken() {
 // send and receive messages from the Web Player.
 try {
   (function () {
+    isZoningApp = !!window.location.href && !!window.location.href.indexOf('zoning=true');
     var $global = Function('return this')(); // eslint-disable-line
 
     // _epBridge exists: Java Player
@@ -206,6 +208,10 @@ exports.default = {
     console.log('[Player SDK] Sending message to URL ' + url + ' with appToken ' + appToken);
 
     // appToken identifies specific instance of the App.
+    if (!appToken) {
+      var match = url.match(/apptoken=([^&]*[a-z|0-9])/);
+      appToken = match && match[1] || '';
+    }
     msg.appToken = appToken;
 
     // We need to send app url with the message so that Web Player knows which application sent
@@ -237,7 +243,7 @@ exports.default = {
       responseMap.set(token, [resolve, reject]);
       msg.token = token;
 
-      if (!appToken) {
+      if (isZoningApp && !appToken) {
         delayedMessages.push(msg);
       } else {
         console.log('[Player SDK] Message to be sent: ' + (0, _stringify2.default)(msg));

--- a/dist/es5/settings.js
+++ b/dist/es5/settings.js
@@ -89,5 +89,23 @@ exports.default = {
       console.log('[Player SDK] Settings: Returning setting get-locale: ' + (payload && payload.value));
       return payload && payload.value ? payload.value : 'en';
     });
+  },
+
+  get orientation() {
+    return settingsSender({
+      action: 'get-orientation'
+    }).then(function (payload) {
+      console.log('[Player SDK] Settings: Returning setting get-orientation: ' + (payload && payload.value));
+      return payload && payload.value;
+    });
+  },
+
+  get zoning() {
+    return settingsSender({
+      action: 'get-zoning-info'
+    }).then(function (payload) {
+      console.log('[Player SDK] Settings: Returning setting get-zoning-info: ' + (payload && payload.value));
+      return payload && payload.value;
+    });
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enplug/player-sdk",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "MIT",
   "description": "The JavaScript SDK for Enplug Player Apps",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enplug/player-sdk",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "license": "MIT",
   "description": "The JavaScript SDK for Enplug Player Apps",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enplug/player-sdk",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "MIT",
   "description": "The JavaScript SDK for Enplug Player Apps",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enplug/player-sdk",
-  "version": "0.3.4",
+  "version": "0.3.6",
   "license": "MIT",
   "description": "The JavaScript SDK for Enplug Player Apps",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enplug/player-sdk",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "license": "MIT",
   "description": "The JavaScript SDK for Enplug Player Apps",
   "main": "index.js",
@@ -35,7 +35,7 @@
     "tdd": "nodemon -q -d 200 -i dist -w src -w tests -x 'npm test'",
     "dev": "npm-run-all compile -p watch tdd -c",
     "prerelease": "npm run compile",
-    "release": "npm version patch && npm run prerelease && npm publish"
+    "release": "npm run prerelease && npm publish"
   },
   "dependencies": {
     "babel-plugin-transform-runtime": "^6.9.0"

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -21,6 +21,8 @@ const RESPONSE_TIMEOUT = (60 * 1000);
 
 var epBridge = null;
 var responseMap = new Map();
+var appToken = null;
+var delayedMessages = [];
 
 
 /**
@@ -102,8 +104,12 @@ epBridge.receive = function (json) {
     const meta = data.meta || {};
     const token = data.token;
 
-    console.log(`[Player SDK] Received message with action ${action}`, data);
+    console.debug(`[Player SDK] Received message with action ${action}`, data);
 
+    if (data && data.action === 'set-app-token') {
+      console.log(`[Player SDK] Storing appToken ${data.appToken}`);
+      appToken = data.appToken;
+    }
 
     // if there is a token we can just resolve the promise and be done
     // if it was an error the payload has been transformed to an error
@@ -119,7 +125,7 @@ epBridge.receive = function (json) {
     // if we pass more info in the payload this will
     // need to be changed to not throw that data away
     if (isError) {
-      console.error(`[Player SDK] Error received: ${payload.message}`, payload);
+      console.log(`[Player SDK] Error received: ${payload.message}`, payload);
       // tweak payload to be the error object
       payload = new EnplugError(payload.message || '');
     }
@@ -165,12 +171,10 @@ export default {
     }, message);
     var url = window.location.href;
 
-    console.log(`[Player SDK] Sending message to URL ${url}`);
+    console.debug(`[Player SDK] Sending message to URL ${url} with appToken ${appToken}`);
 
     // appToken identifies specific instance of the App.
-    var match = url.match(/apptoken=([^&]*[a-z|0-9])/);
-    msg.appToken = match && match[1] || '';
-
+    msg.appToken = appToken;
 
     // We need to send app url with the message so that Web Player knows which application sent
     // a message.

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -183,6 +183,10 @@ export default {
     console.log(`[Player SDK] Sending message to URL ${url} with appToken ${appToken}`);
 
     // appToken identifies specific instance of the App.
+    if (!appToken) {
+      var match = url.match(/apptoken=([^&]*[a-z|0-9])/);
+      appToken = match && match[1] || '';
+    }
     msg.appToken = appToken;
 
     // We need to send app url with the message so that Web Player knows which application sent

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -22,6 +22,7 @@ const RESPONSE_TIMEOUT = (60 * 1000);
 var epBridge = null;
 var responseMap = new Map();
 var appToken = null;
+var isZoningApp = false;
 var delayedMessages = [];
 
 
@@ -44,6 +45,7 @@ function createToken() {
 // Check for the existence of the global bridge object. If it doesn't, create one so that it can
 // send and receive messages from the Web Player.
 try {
+  isZoningApp = !!window.location.href && !!window.location.href.indexOf('zoning=true');
   let $global = Function('return this')(); // eslint-disable-line
 
   // _epBridge exists: Java Player
@@ -222,7 +224,7 @@ export default {
       responseMap.set(token, [resolve, reject]);
       msg.token = token;
 
-      if (!appToken) {
+      if (isZoningApp && !appToken) {
         delayedMessages.push(msg);
       } else {
         console.log(`[Player SDK] Message to be sent: ${JSON.stringify(msg)}`);


### PR DESCRIPTION
A change to Player SDK which prepares us to remove appTokens from the URLs. Having appTokens appended to the URL causes those URLs to be unique and therefore useless for the purpose of caching.

What happens:
- We leave URL appToken parsing for temporary backwards compatibility
- We check the URL for zoning=true. This is necessary to set the flag which helps us run apps correctly without zoning (in non-zoning, we never get the appToken so we want to avoid a situation where we queue the messages and never send them)
- We wait for and store appToken which we get in a regular message (via receive function)
- We queue all the outgoing messages until the token is provided. Once the token is received, the queued messages are sent in order they were received.

Once the URL appToken parsing is removed, the app will rely strictly on the appToken received via the message.

